### PR TITLE
Generate unique order id for Paytm

### DIFF
--- a/Paytm_WHMCS_v6.x-7.x_Kit-master/Paytm/gateways/paytm.php
+++ b/Paytm_WHMCS_v6.x-7.x_Kit-master/Paytm/gateways/paytm.php
@@ -19,7 +19,7 @@ function paytm_link($params) {
 
 	$merchant_id = $params['merchant_id'];
 	$secret_key=$params['merchant_key'];
-	$order_id = $params['invoiceid'];
+	$order_id = $params['invoiceid'].'-'.time();
 	$website= $params['website'];
 	$industry_type= $params['industry_type'];
 	$channel_id="WEB";	


### PR DESCRIPTION
As WHMCS dont have unique order for repeated payments or failed payments, so add timestamp and - (dash) to make unique every time